### PR TITLE
Fix grammar of Fortran floating point numbers

### DIFF
--- a/src/F2x/grammar/fortran.g
+++ b/src/F2x/grammar/fortran.g
@@ -92,7 +92,7 @@ T_DEFINED_OP : '\.[a-zA-Z]+\.' (%unless
 );
 
 T_PERIOD_EXPONENT 
-    : '(\.[0-9]+[EedD][+-]?[0-9]+)|(\.[EedD][+-]?[0-9]+)|(\.[0-9]+)|([0-9]+[eEdD][+-]?[0-9]+)'
+    : '(\.[0-9]*[EedD][+-]?[0-9]+)|(\.[0-9]*)|([eEdD][+-]?[0-9]+)'
     ;
 
 T_HOLLERITH : '$no hollerith'; // shouldn't be recognized


### PR DESCRIPTION
Fortran allows to omit zeros behind the decimal point, e.g. 1. for 1.0...
Examples for floating point numbers:
1.0
1.
1e0
