### PR TITLE
Fix grammar of Fortran line continuation

### DIFF
--- a/src/F2x/grammar/fortran.g
+++ b/src/F2x/grammar/fortran.g
@@ -17,7 +17,7 @@ T_EOL
     ;
 
 CONTINUE_CHAR
-    : '&[ \r\t\u000C]*(![^\n\r]*)?\r?\n' (%newline) (%ignore)
+    : '&[ \r\t\u000C]*(![^\n\r]*)?\r?\n([ \t\u000C]*&)?' (%newline) (%ignore)
     ;
 
 T_CHAR_CONSTANT


### PR DESCRIPTION
You are allowed to put an additional & in the next line, e.g.:

call something( & ! this is the first line
  &                  arg) ! and this the second one
